### PR TITLE
Remove job ttl

### DIFF
--- a/migration/phases.go
+++ b/migration/phases.go
@@ -305,7 +305,6 @@ func newJob(sourcePVC, targetPVC, namespace string) *batchv1.Job {
 			},
 		},
 		Spec: batchv1.JobSpec{
-			TTLSecondsAfterFinished: new(int32),
 			Completions:             &compl,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{


### PR DESCRIPTION
A job ttl of 0 causes the job to be immediately cleaned up by kubernetes.
This can break relokator if the job is removed before relokator realizes it
has completed. This probably never came up before as the ttl field only works
since v1.21.

https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs